### PR TITLE
[FIX] fix bug with wrong commercial partner after signup

### DIFF
--- a/auth_signup_parent_company_selection/models/__init__.py
+++ b/auth_signup_parent_company_selection/models/__init__.py
@@ -1,1 +1,2 @@
 from . import res_partner_industry
+from . import res_users

--- a/auth_signup_parent_company_selection/models/res_users.py
+++ b/auth_signup_parent_company_selection/models/res_users.py
@@ -1,0 +1,23 @@
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    @api.model
+    def signup(self, values, token=None):
+        """If partner was set, run commercial partner computation to ensure
+        commercial_partner_id reflects the parent_id that got set"""
+
+        # result is in format: (login, password)
+        result = super().signup(values, token=token)
+
+        user = self.search([("login", "=", result[0])], limit=1)
+        if user.partner_id.parent_id:
+            user.partner_id._compute_commercial_partner()
+
+        return result


### PR DESCRIPTION
- commercial_partner_id would not get immediately calculated after signup, so the new user might not see e.g. all parent company's invoice addresses if they went to shop and checkout right after registering